### PR TITLE
Update to build with Docker >= 1.11

### DIFF
--- a/docker_driver.go
+++ b/docker_driver.go
@@ -320,3 +320,7 @@ func (d ndvpDriver) List(r volume.Request) volume.Response {
 
 	return volume.Response{Volumes: vols}
 }
+
+func (d ndvpDriver) Capabilities(r volume.Request) volume.Response {
+	return volume.Response{Capabilities: volume.Capability{Scope: "global"}}
+}


### PR DESCRIPTION
Docker 1.11 introduced the Capabilities method, for
now it's not very exciting and just indicates Scope with
the choice of Local or Global, indicating whether the driver
can serve up volumes to a single node only, or to every node
in a Docker Cluster.

All of the ndvp backends currently operate on a Global scope, so
we just add a simple implementaiton directly in the interface
for now.

In the future as we add more Capabilities we'll want to allow
each backend to report their own data, but for now this should
be fairly straight forward.