### PR TITLE
E-Series: Resolve issue with delete volume

### DIFF
--- a/storage_drivers/eseries_iscsi.go
+++ b/storage_drivers/eseries_iscsi.go
@@ -163,11 +163,15 @@ func (d *ESeriesStorageDriver) Destroy(name string) error {
 		return fmt.Errorf("Problem determining host initiator iqns error: %v", errIqn)
 	}
 
-	log.Debugf("ESeriesStorageDriver#Destroy(%v) - iqn=%s", name, iqns[0]) //Going to assume a single IQN name for our host right now
+	//Going to assume a single IQN name for our host right now
+	var iqn string = iqns[0]
 
-	hostRef, error := d.storage.VerifyHostIQN(iqns[0])
-	if error != nil {
-		return fmt.Errorf("Host IQN (%s) not found on target E-Series array! error=%s", errIqn, error)
+	log.Debugf("ESeriesStorageDriver#Destroy(%v) - iqn=%s", name, iqn)
+
+	//We don't want to fail the operation if we can't find a host matching the IQN, but we want to log a warning
+	hostRef, verifyIqnErr := d.storage.VerifyHostIQN(iqn)
+	if verifyIqnErr != nil {
+		log.Warnf("Host IQN (%s) not found on target E-Series array! error=%s", iqn, verifyIqnErr)
 	}
 
 	log.Debugf("ESeriesStorageDriver#Destroy(%v) - HostRef=%s", name, hostRef)


### PR DESCRIPTION
When the host iqn was not properly defined on a host, it was possible
to define a new volume using docker volume create, but not possible
to delete the volume.

This patch changes an error into a warning message to allow the
deletion to proceed unless the volume has been mapped to a different
host.

resolves #22