### PR TITLE
E-Series: Tag volumes to identify usage on back-end

### DIFF
--- a/apis/eseries/eseries_structs.go
+++ b/apis/eseries/eseries_structs.go
@@ -34,13 +34,20 @@ type VolumeGroupExResponse struct {
 
 //Create a volume
 type MsgVolumeEx struct {
-	VolumeGroupRef   string `json:"poolId"`
-	Name             string `json:"name"`
-	SizeUnit         string `json:"sizeUnit"` //bytes, b, kb, mb, gb, tb, pb, eb, zb, yb
-	Size             int    `json:"size"`
-	SegmentSize      int    `json:"segSize"`
-	DataAssurance    bool   `json:"dataAssuranceEnabled,omitempty"`
-	OwningController string `json:"owningControllerId,omitempty"`
+	VolumeGroupRef   string      `json:"poolId"`
+	Name             string      `json:"name"`
+	SizeUnit         string      `json:"sizeUnit"` //bytes, b, kb, mb, gb, tb, pb, eb, zb, yb
+	Size             int         `json:"size"`
+	SegmentSize      int         `json:"segSize"`
+	DataAssurance    bool        `json:"dataAssuranceEnabled,omitempty"`
+	OwningController string      `json:"owningControllerId,omitempty"`
+	VolumeTags       []VolumeTag `json:"metaTags,omitempty"`
+}
+
+//Volume Metadata Tag
+type VolumeTag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type MsgVolumeExResponse struct {

--- a/storage_drivers/eseries_iscsi.go
+++ b/storage_drivers/eseries_iscsi.go
@@ -35,10 +35,14 @@ func (d ESeriesStorageDriver) Name() string {
 	return "eseries-iscsi"
 }
 
+// Return the storage protocol that this driver uses
+func (d ESeriesStorageDriver) Protocol() string {
+	return "iscsi"
+}
+
 // Initialize from the provided config
 func (d *ESeriesStorageDriver) Initialize(configJSON string) error {
 	log.Debugf("ESeriesStorageDriver#Initialize(...)")
-
 	config := &ESeriesStorageDriverConfig{}
 
 	// decode configJSON into ESeriesStorageDriverConfig object
@@ -69,6 +73,9 @@ func (d *ESeriesStorageDriver) Initialize(configJSON string) error {
 		PasswordArray:     config.PasswordArray,
 		ArrayRegistered:   config.ArrayRegistered,
 		HostDataIP:        config.HostDataIP,
+		Protocol:          d.Protocol(),
+		DriverName:        config.CommonStorageDriverConfig.StorageDriverName,
+		Version:           config.CommonStorageDriverConfig.Version,
 	})
 
 	validationErr := d.Validate()


### PR DESCRIPTION
Add a volume metadata tag to defined E-Series volumes to better identify their usage in the back-end's UI and other management plugins.