### PR TITLE
Returning an error on non-200 HTTP responses in SendZapi

### DIFF
--- a/azgo/common.go
+++ b/azgo/common.go
@@ -68,5 +68,11 @@ func (o *ZapiRunner) SendZapi(r ZAPIRequest) (*http.Response, error) {
 	log.Debugf("response Status: %s", resp.Status)
 	log.Debugf("response Headers: %s", resp.Header)
 
+	if resp.StatusCode != http.StatusOK {
+		http_response := http.StatusText(resp.StatusCode)
+		err := fmt.Errorf("%v (%v)", resp.StatusCode, http_response)
+		return resp, err
+	}
+
 	return resp, err
 }


### PR DESCRIPTION
This addresses: azgo: Handle SendZapi HTTP Responses #40

Incorrect password used in ontap-nas.json



>  sudo netappdvp --config=/etc/netappdvp/ontap-nas.json
ERRO[0004] err: 401 (Unauthorized)
ERRO[0004] Problem initializing storage driver: 'ontap-nas' error: Problem validating OntapNASStorageDriver error: Could not validate credentials for admin@CXE, error: 401 (Unauthorized)
