### PR TITLE
Specify export policy in config

### DIFF
--- a/storage_drivers/ontap_nas.go
+++ b/storage_drivers/ontap_nas.go
@@ -159,7 +159,7 @@ func (d *OntapNASStorageDriver) Create(name string, opts map[string]string) erro
 	snapshotPolicy := utils.GetV(opts, "snapshotPolicy", "none")
 	unixPermissions := utils.GetV(opts, "unixPermissions", "---rwxr-xr-x")
 	snapshotDir := utils.GetV(opts, "snapshotDir", "true")
-	exportPolicy := utils.GetV(opts, "exportPolicy", "default")
+	exportPolicy := utils.GetV(opts, "exportPolicy", d.Config.ExportPolicy)
 	aggregate := utils.GetV(opts, "aggregate", d.Config.Aggregate)
 
 	log.WithFields(log.Fields{

--- a/storage_drivers/storage_drivers.go
+++ b/storage_drivers/storage_drivers.go
@@ -55,6 +55,7 @@ type OntapStorageDriverConfig struct {
 	DataLIF                   string `json:"dataLIF"`
 	IgroupName                string `json:"igroupName"`
 	SVM                       string `json:"svm"`
+	ExportPolicy		  string `json:"exportpolicy"`
 	Username                  string `json:"username"`
 	Password                  string `json:"password"`
 	Aggregate                 string `json:"aggregate"`


### PR DESCRIPTION
In most configurations I see out in the wild the default export policy only has one rule which grants all systems (0.0.0.0/0) read-only access. This is obviously an issue when creating volumes which you want to write to (docker-created NFS volumes). With that said I have made a few simple changes to allow for an export policy to be specified in the JSON config file so an administrator can specify which export policy gets assigned to volumes created by the plugin.

Thanks,

Dan