### PR TITLE
Ignore Volume Not Found on Delete

### DIFF
--- a/apis/sfapi/volume.go
+++ b/apis/sfapi/volume.go
@@ -53,9 +53,11 @@ func (c *Client) GetVolumeByName(n string, acctID int64) (v Volume, err error) {
 	}
 
 	if len(vols) > 1 {
-		err = fmt.Errorf("Found more than one Volume with Name: %s for Account: %d", n, acctID)
+		log.Errorf("Multiple volumes detected with the same name: %s", n)
+		err = errors.New("Multiple Volumes found")
 	} else if len(vols) < 1 {
-		err = fmt.Errorf("Failed to find any Volumes with Name: %s for Account: %d", n, acctID)
+		log.Errorf("No volumes detected with the name: %s", n)
+		err = errors.New("Volume not found")
 	}
 	return v, err
 }


### PR DESCRIPTION
Detect volume not found errors on delete, log and continue.

One corner case is that we could have some attachments on the host,
so make a feable attempt to clean them up just incase.