### PR TITLE
Fix SF Naming issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Multiple instances of the nDVP can run concurrently on the same host.  The allow
     EOF
     ```
 
-3. After placing the binary and creating the configuration file(s), start the nDVP daemon using the desired configuration file.  
+3. After placing the binary and creating the configuration file(s), start the nDVP daemon using the desired configuration file.
 
     **Note:** Unless specified, the default name for the volume driver will be "netapp".
 
@@ -241,6 +241,14 @@ supplied is prepended with "netappdvp_".  _("netappdvp-" for SolidFire.)_
 If you wish to use a different prefix, you can specify it with this directive.  Alternatively, you can use
 *pre-existing* volumes with the volume plugin by setting `storagePrefix` to an empty string, "".
 
+*solidfire specific recommendation* do not use a storagePrefix (including the default)
+By default the SolidFire driver will ignore this setting and not use a prefix.
+We recommend using either a specific tenantID for docker volume mapping or
+using the attribute data which is populated with the docker version, driver
+info and raw name from docker in cases where any name munging may have been
+used.
+
+
 **A note of caution**: `docker volume rm` will *delete* these volumes just as it does volumes created by the
 plugin using the default prefix.  Be very careful when using pre-existing volumes!
 
@@ -305,25 +313,25 @@ In addition to the global configuration values above, when using E-Series, these
 | controllerB       | IP address of controller B                                                | 10.0.0.6      |
 | passwordArray     | Password for storage array if set                                         | blank/empty   |
 | hostData_IP       | Host iSCSI IP address (if multipathing just choose either one)            | 10.0.0.101    |
- 
+
 ### Example E-Series Config File
 
 **Example for eseries-iscsi driver**
 
 ```json
-{    
-	"version": 1,    
-	"storageDriverName": "eseries-iscsi",    
-	"debug": true,    
-	"webProxyHostname": "localhost",    
+{
+	"version": 1,
+	"storageDriverName": "eseries-iscsi",
+	"debug": true,
+	"webProxyHostname": "localhost",
 	"webProxyPort": "8443",
 	"webProxyUseHTTP": false,
 	"webProxyVerifyTLS": true,
-	"username": "rw",    
-	"password": "rw",    
-	"controllerA": "10.0.0.5",    
-	"controllerB": "10.0.0.6",    
-	"passwordArray": "",    
+	"username": "rw",
+	"password": "rw",
+	"controllerA": "10.0.0.5",
+	"controllerB": "10.0.0.6",
+	"passwordArray": "",
 	"hostData_IP": "10.0.0.101"
 }
 ```
@@ -332,7 +340,7 @@ In addition to the global configuration values above, when using E-Series, these
 
 The E-Series Docker driver assumes that you have a volume group or a DDP pool
 pre-configured (N number of drives; segment size; RAID type; ...). The driver
-then allocates Docker volumes out of this volume group or DDP pool. The volume group 
+then allocates Docker volumes out of this volume group or DDP pool. The volume group
 and/or DDP pool must be given a specific name and there must be two groups allocated.
 For example, you could create a volume group/DDP pool named 'netappdvp_hdd' and another named 'netappdvp_ssd'.
 
@@ -340,8 +348,8 @@ When creating a docker volume you can specify the volume size as well as the all
 '-o' option and the tags 'size' and 'mediaType'. Note that these are optional; if unspecified, the defaults will
 be a 1 GB volume allocated from the HDD pool. An example of using these tags to create a 2 GB
 volume from the SSD volume group/DDP pool:
- 	
-	docker volume create -d netapp --name my_vol -o size=2g -o mediaType=ssd 	
+
+	docker volume create -d netapp --name my_vol -o size=2g -o mediaType=ssd
 
 Note that the current driver is meant to be used with iSCSI.
 
@@ -365,6 +373,12 @@ In addition to the global configuration values above, when using SolidFire, thes
 | DefaultVolSz      | Volume size in GiB                                                        | 1                          |
 | InitiatorIFace    | Specify interface when restricting iSCSI traffic to non-default interface | "default"                  |
 | Types             | QoS specifications                                                        | See below                  |
+| LegacyNamePrefix  | Prefix for upgraded NDVP installs                                         | "netappdvp-"               |
+
+
+**LegacyNamePrefix** If you used a version of ndvp prior to 1.32 and perform an
+upgrade with existing volumes, you'll need to set this value in order to access
+your old volumes that were mapped via the volume-name method.
 
 ### Example Solidfire Config File
 

--- a/apis/sfapi/api.go
+++ b/apis/sfapi/api.go
@@ -31,13 +31,14 @@ type Client struct {
 
 // Config holds the configuration data for the Client to communicate with a SolidFire storage system
 type Config struct {
-	TenantName     string
-	EndPoint       string
-	DefaultVolSz   int64 //Default volume size in GiB
-	MountPoint     string
-	SVIP           string
-	InitiatorIFace string //iface to use of iSCSI initiator
-	Types          *[]VolType
+	TenantName       string
+	EndPoint         string
+	DefaultVolSz     int64 //Default volume size in GiB
+	MountPoint       string
+	SVIP             string
+	InitiatorIFace   string //iface to use of iSCSI initiator
+	Types            *[]VolType
+	LegacyNamePrefix string
 }
 
 // VolType holds quality of service configuration data

--- a/apis/sfapi/volume.go
+++ b/apis/sfapi/volume.go
@@ -72,8 +72,10 @@ func (c *Client) GetVolumesByDockerName(dockerName string, acctID int64) (v []Vo
 	}
 	for _, vol := range volumes {
 		attrs, _ := vol.Attributes.(map[string]interface{})
-		log.Debugf("Looking for docker-name: %+v\n", attrs)
+		log.Debugf("Looking for docker-name %+v in %+v\n", dockerName, attrs)
 		if attrs["docker-name"] == dockerName && vol.Status == "active" {
+			foundVolumes = append(foundVolumes, vol)
+		} else if vol.Name == strings.Replace(dockerName, "_", "-", -1) {
 			foundVolumes = append(foundVolumes, vol)
 		}
 	}

--- a/storage_drivers/eseries_iscsi.go
+++ b/storage_drivers/eseries_iscsi.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/netapp/netappdvp/apis/eseries"
 	"github.com/netapp/netappdvp/utils"
 
@@ -392,4 +393,11 @@ func (d *ESeriesStorageDriver) SnapshotList(name string) ([]CommonSnapshot, erro
 // Create a volume clone
 func (d *ESeriesStorageDriver) CreateClone(name, source, snapshot, newSnapshotPrefix string) error {
 	return fmt.Errorf("Cloning with E-Series is not yet supported")
+}
+
+// VolumeList retrieves a list of volumes according to backend device
+func (d *ESeriesStorageDriver) VolumeList(vDir string) ([]*volume.Volume, error) {
+	// Currently ESeries utilizes the parent directory method, this function is
+	// an empty stub for the driver interface
+	return nil, fmt.Errorf("VolumeList not implemented in ESeries driver.")
 }

--- a/storage_drivers/ontap_nas.go
+++ b/storage_drivers/ontap_nas.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/netapp/netappdvp/apis/ontap"
 	"github.com/netapp/netappdvp/azgo"
 	"github.com/netapp/netappdvp/utils"
@@ -284,4 +285,11 @@ func (d *OntapNASStorageDriver) DefaultSnapshotPrefix() string {
 // Return the list of snapshots associated with the named volume
 func (d *OntapNASStorageDriver) SnapshotList(name string) ([]CommonSnapshot, error) {
 	return GetSnapshotList(name, d.API)
+}
+
+// VolumeList retrieves a list of volumes according to backend device
+func (d *OntapNASStorageDriver) VolumeList(vDir string) ([]*volume.Volume, error) {
+	// Currently Ontap utilizes the parent directory method, this function is
+	// an empty stub for the driver interface
+	return nil, fmt.Errorf("VolumeList not implemented in Ontapdriver.")
 }

--- a/storage_drivers/ontap_san.go
+++ b/storage_drivers/ontap_san.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/netapp/netappdvp/apis/ontap"
 	"github.com/netapp/netappdvp/azgo"
 	"github.com/netapp/netappdvp/utils"
@@ -441,4 +442,11 @@ func (d *OntapSANStorageDriver) DefaultSnapshotPrefix() string {
 // Return the list of snapshots associated with the named volume
 func (d *OntapSANStorageDriver) SnapshotList(name string) ([]CommonSnapshot, error) {
 	return GetSnapshotList(name, d.API)
+}
+
+// VolumeList retrieves a list of volumes according to backend device
+func (d *OntapSANStorageDriver) VolumeList(vDir string) ([]*volume.Volume, error) {
+	// Currently ESeries utilizes the parent directory method, this function is
+	// an empty stub for the driver interface
+	return nil, fmt.Errorf("VolumeList not implemented in Ontap driver.")
 }

--- a/storage_drivers/solidfire_san.go
+++ b/storage_drivers/solidfire_san.go
@@ -5,10 +5,12 @@ package storage_drivers
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/alecthomas/units"
+	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/netapp/netappdvp/apis/sfapi"
 	"github.com/netapp/netappdvp/utils"
 
@@ -43,13 +45,14 @@ func formatOpts(opts map[string]string) {
 
 // SolidfireSANStorageDriver is for iSCSI storage provisioning
 type SolidfireSANStorageDriver struct {
-	Initialized    bool
-	Config         SolidfireStorageDriverConfig
-	Client         *sfapi.Client
-	TenantID       int64
-	DefaultVolSz   int64
-	VagID          int64
-	InitiatorIFace string
+	Initialized      bool
+	Config           SolidfireStorageDriverConfig
+	Client           *sfapi.Client
+	TenantID         int64
+	DefaultVolSz     int64
+	VagID            int64
+	LegacyNamePrefix string
+	InitiatorIFace   string
 }
 
 // Name is for returning the name of this driver
@@ -88,12 +91,13 @@ func (d *SolidfireSANStorageDriver) Initialize(configJSON string) error {
 	defaultSizeGiB := c.DefaultVolSz * int64(units.GiB)
 	svip := c.SVIP
 	cfg := sfapi.Config{
-		TenantName:     c.TenantName,
-		EndPoint:       c.EndPoint,
-		DefaultVolSz:   defaultSizeGiB,
-		SVIP:           c.SVIP,
-		InitiatorIFace: c.InitiatorIFace,
-		Types:          c.Types,
+		TenantName:       c.TenantName,
+		EndPoint:         c.EndPoint,
+		DefaultVolSz:     defaultSizeGiB,
+		SVIP:             c.SVIP,
+		InitiatorIFace:   c.InitiatorIFace,
+		Types:            c.Types,
+		LegacyNamePrefix: c.LegacyNamePrefix,
 	}
 	defaultTenantName := c.TenantName
 
@@ -125,6 +129,11 @@ func (d *SolidfireSANStorageDriver) Initialize(configJSON string) error {
 		tenantID = account.AccountID
 	}
 
+	legacyNamePrefix := "netappdvp-"
+	if c.LegacyNamePrefix != "" {
+		legacyNamePrefix = c.LegacyNamePrefix
+	}
+
 	iscsiInterface := "default"
 	if c.InitiatorIFace != "" {
 		iscsiInterface = c.InitiatorIFace
@@ -143,6 +152,7 @@ func (d *SolidfireSANStorageDriver) Initialize(configJSON string) error {
 	d.Client = client
 	d.DefaultVolSz = defaultVolSize
 	d.InitiatorIFace = iscsiInterface
+	d.LegacyNamePrefix = legacyNamePrefix
 	log.WithFields(log.Fields{
 		"TenantID":       tenantID,
 		"DefaultVolSz":   defaultVolSize,
@@ -187,46 +197,6 @@ func (d *SolidfireSANStorageDriver) Validate() error {
 	return nil
 }
 
-// Strip storage prefix name to simple Docker Name
-func (d *SolidfireSANStorageDriver) StripVolumePrefix(name string) string {
-	// Different backends supported by NDVP have different restrictions on
-	// what characters are supported in their Name field.  Some prohibit '-'
-	// while others (including SolidFire) prohibit '_'.  Rather than deal with
-	// making the translation of the prefix as well as possible conflicts in
-	// multi-node environments (ie prefix mismatch between nodes) we remvoe the
-	// reliance on the prefix in the name and the limitations by just stripping
-	// out the *real* Docker Name and using that in the attributes as the
-	// accesor.  This becomes even more annoying because we're allowed to have
-	// different prefixes for Volumes and Snapshots.
-	dockerName := name
-	prefix := string(d.Config.CommonStorageDriverConfig.StoragePrefixRaw)
-	prefix = strings.Replace(prefix, "\"", "", -1)
-	if prefix != "" {
-		dockerName = strings.Replace(name, prefix, "", -1)
-	}
-	return dockerName
-}
-
-// Strip snapshot prefix name to simple Docker Name
-func (d *SolidfireSANStorageDriver) StripSnapshotPrefix(name string) string {
-	// Different backends supported by NDVP have different restrictions on
-	// what characters are supported in their Name field.  Some prohibit '-'
-	// while others (including SolidFire) prohibit '_'.  Rather than deal with
-	// making the translation of the prefix as well as possible conflicts in
-	// multi-node environments (ie prefix mismatch between nodes) we remvoe the
-	// reliance on the prefix in the name and the limitations by just stripping
-	// out the *real* Docker Name and using that in the attributes as the
-	// accesor.  This becomes even more annoying because we're allowed to have
-	// different prefixes for Volumes and Snapshots.
-	dockerName := name
-	prefix := string(d.Config.CommonStorageDriverConfig.SnapshotPrefixRaw)
-	prefix = strings.Replace(prefix, "\"", "", -1)
-	if prefix != "" {
-		dockerName = strings.Replace(name, prefix, "", -1)
-	}
-	return dockerName
-}
-
 // Make SolidFire name
 func MakeSolidFireName(name string) string {
 	return strings.Replace(name, "_", "-", -1)
@@ -239,14 +209,11 @@ func (d *SolidfireSANStorageDriver) Create(name string, opts map[string]string) 
 	var req sfapi.CreateVolumeRequest
 	var qos sfapi.QoS
 	var vsz int64
-	var dName = d.StripVolumePrefix(name)
 	var meta = map[string]string{"platform": "Docker-NDVP",
-		"ndvp-version": DriverVersion + " ["+ExtendedDriverVersion+"]",
-		"docker-name": dName}
+		"ndvp-version": DriverVersion + " [" + ExtendedDriverVersion + "]",
+		"docker-name":  name}
 
-	log.Debugf("GetVolumeByDockerName: %s, %d", dName, d.TenantID)
-	log.Debugf("Options passed in to create: %+v", opts)
-	v, err := d.Client.GetVolumeByDockerName(dName, d.TenantID)
+	v, err := d.getVolume(name)
 	if err == nil && v.VolumeID != 0 {
 		log.Infof("Found existing Volume by name: %s", name)
 		return nil
@@ -302,11 +269,12 @@ func (d *SolidfireSANStorageDriver) CreateClone(name, source, snapshot, newSnaps
 	log.Debugf("SolidfireSANStorageDriver#CreateClone(%v, %v, %v, %v)", name, source, snapshot, newSnapshotPrefix)
 
 	var req sfapi.CloneVolumeRequest
-	var dName = d.StripVolumePrefix(name)
-	var dSrcName = d.StripVolumePrefix(source)
+	var meta = map[string]string{"platform": "Docker-NDVP",
+		"ndvp-version": DriverVersion + " [" + ExtendedDriverVersion + "]",
+		"docker-name":  name}
 
 	// Check to see if the clone already exists
-	v, err := d.Client.GetVolumeByDockerName(dName, d.TenantID)
+	v, err := d.getVolume(name)
 	if err == nil && v.VolumeID != 0 {
 		// The clone already exists; skip and call it a success
 		return nil
@@ -322,14 +290,15 @@ func (d *SolidfireSANStorageDriver) CreateClone(name, source, snapshot, newSnaps
 	}
 
 	// Get the volume ID for the source volume
-	v, err = d.Client.GetVolumeByDockerName(dSrcName, d.TenantID)
+	v, err = d.getVolume(source)
 	if err != nil || v.VolumeID == 0 {
 		return fmt.Errorf("Failed to find source volume: error: %v", err)
 	}
 
 	// Create the clone of the source volume with the name specified
 	req.VolumeID = v.VolumeID
-	req.Name = name
+	req.Name = MakeSolidFireName(name)
+	req.Attributes = meta
 	_, err = d.Client.CloneVolume(&req)
 	if err != nil {
 		return fmt.Errorf("Failed to create clone: error: %v", err)
@@ -340,9 +309,8 @@ func (d *SolidfireSANStorageDriver) CreateClone(name, source, snapshot, newSnaps
 // Destroy the requested docker volume
 func (d *SolidfireSANStorageDriver) Destroy(name string) error {
 	log.Debugf("SolidfireSANStorageDriver#Destroy(%v)", name)
-	var dName = d.StripVolumePrefix(name)
 
-	v, err := d.Client.GetVolumeByDockerName(dName, d.TenantID)
+	v, err := d.getVolume(name)
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve volume named %s during Remove operation;  error: %v", name, err)
 	}
@@ -363,9 +331,7 @@ func (d *SolidfireSANStorageDriver) Destroy(name string) error {
 // Attach the lun
 func (d *SolidfireSANStorageDriver) Attach(name, mountpoint string, opts map[string]string) error {
 	log.Debugf("SolidfireSANStorageDriver#Attach(%v, %v, %v)", name, mountpoint, opts)
-	var dName = d.StripVolumePrefix(name)
-
-	v, err := d.Client.GetVolumeByDockerName(dName, d.TenantID)
+	v, err := d.getVolume(name)
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve volume by name in mount operation;  name: %v error: %v", name, err)
 	}
@@ -394,14 +360,12 @@ func (d *SolidfireSANStorageDriver) Attach(name, mountpoint string, opts map[str
 // Detach the volume
 func (d *SolidfireSANStorageDriver) Detach(name, mountpoint string) error {
 	log.Debugf("SolidfireSANStorageDriver#Detach(%v, %v)", name, mountpoint)
-	var dName = d.StripVolumePrefix(name)
-
 	umountErr := utils.Umount(mountpoint)
 	if umountErr != nil {
 		return fmt.Errorf("Problem unmounting docker volume: %v mountpoint: %v error: %v", name, mountpoint, umountErr)
 	}
 
-	v, err := d.Client.GetVolumeByDockerName(dName, d.TenantID)
+	v, err := d.getVolume(name)
 	if err != nil {
 		return fmt.Errorf("Problem looking up volume name: %v TenantID: %v error: %v", name, d.TenantID, err)
 	}
@@ -420,12 +384,30 @@ func (d *SolidfireSANStorageDriver) DefaultSnapshotPrefix() string {
 	return "netappdvp-"
 }
 
+// Return the list of volumes according to backend device
+func (d *SolidfireSANStorageDriver) VolumeList(vDir string) ([]*volume.Volume, error) {
+	log.Info("List volumes from SolidFire backend")
+	var req sfapi.ListVolumesForAccountRequest
+	var vols []*volume.Volume
+	req.AccountID = d.TenantID
+	volumes, err := d.Client.ListVolumesForAccount(&req)
+	for _, v := range volumes {
+		if v.Status != "deleted" {
+			attrs, _ := v.Attributes.(map[string]interface{})
+			dName := strings.Replace(v.Name, d.LegacyNamePrefix, "", -1)
+			if str, ok := attrs["docker-name"].(string); ok {
+				dName = strings.Replace(str, d.LegacyNamePrefix, "", -1)
+			}
+			vols = append(vols, &volume.Volume{Name: dName, Mountpoint: filepath.Join(vDir, v.Name)})
+		}
+	}
+	return vols, err
+}
+
 // Return the list of snapshots associated with the named volume
 func (d *SolidfireSANStorageDriver) SnapshotList(name string) ([]CommonSnapshot, error) {
 	log.Debugf("SolidfireSANStorageDriver#SnapshotList(%v)", name)
-	var dName = d.StripVolumePrefix(name)
-
-	v, err := d.Client.GetVolumeByDockerName(dName, d.TenantID)
+	v, err := d.getVolume(name)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to retrieve volume by name in snapshot list operation; name: %v error: %v", name, err)
 	}
@@ -447,4 +429,29 @@ func (d *SolidfireSANStorageDriver) SnapshotList(name string) ([]CommonSnapshot,
 	}
 
 	return snapshots, nil
+}
+
+// Get volume using a couple of different methods to support changes after
+// upgrades
+func (d *SolidfireSANStorageDriver) getVolume(name string) (v sfapi.Volume, err error) {
+	// By default we now use the attributes which is the raw docker name so we
+	// can ignore the prefix/translation nonsense for the first go around
+	v, err = d.Client.GetVolumeByDockerName(name, d.TenantID)
+
+	// Ok, the volume may not exist which we expect in a number of cases, but
+	// now we have the annoying challenge of determining, was this in fact
+	// because it DNE, or is it a problem with legacy volume-name munging?
+	if (err != nil) && (d.LegacyNamePrefix != "") {
+		// We'll allow a user to specify the old naming convention in their SF
+		// config and use that to try and find by name using the old
+		// translation method, note that we default this prefix to 'netappdvp-'
+		legacyName := d.LegacyNamePrefix + name
+		legacyName = MakeSolidFireName(legacyName)
+		log.Debugf("Attempting failed search using legacy-name: %s", legacyName)
+		v, err = d.Client.GetVolumeByName(legacyName, d.TenantID)
+	}
+	if err != nil {
+		return v, fmt.Errorf("Failed to retrieve volume: %s (%v)", name, err)
+	}
+	return v, nil
 }

--- a/storage_drivers/storage_drivers.go
+++ b/storage_drivers/storage_drivers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/netapp/netappdvp/apis/sfapi"
 )
 
@@ -14,6 +15,7 @@ const ConfigVersion = 1
 
 // DriverVersion is the actual release version number
 const DriverVersion = "1.3.2"
+
 // ExtendedDriverVersion can be overridden by embeddors such as Trident to uniquify the version string
 var ExtendedDriverVersion = "native"
 
@@ -93,6 +95,7 @@ type SolidfireStorageDriverConfig struct {
 	SVIP                      string
 	InitiatorIFace            string //iface to use of iSCSI initiator
 	Types                     *[]sfapi.VolType
+	LegacyNamePrefix          string //name prefix used in earlier ndvp versions
 }
 
 // CommonSnapshot contains the normalized volume snapshot format we report to Docker
@@ -117,4 +120,5 @@ type StorageDriver interface {
 	DefaultStoragePrefix() string
 	DefaultSnapshotPrefix() string
 	SnapshotList(name string) ([]CommonSnapshot, error)
+	VolumeList(rootDir string) ([]*volume.Volume, error)
 }


### PR DESCRIPTION
This patch fixes up naming issues that have been plaguing the
SolidFire backend option in NDVP.

In order to fix this we do a number of things, like skipping the
use of name prefixes, and just using docker-names (we can still
identify telemetry data via volume attributes).

This means we need to do some extra effort with detecting legacy
names, as well as transposed '_' to '-' symbols in names, so it
requires a bit more effort on the get and list operations.

We also fix things up in terms of writing attributes to clones, and
we start removing the reliance on the file-system mount points as the
source of truth for volume existence for SolidFire by moving that into
a listForAccount API call.

Note that if you share your docker account ID for other things, then
you're doing it wrong, stop doing that. :)

This is a temporary quick fix solution, future changes will be proposed
that break these pieces out a bit and simplify the config as well as the
operations.  This is the first step in that direction, eventually we'll
ease testing and maintenance by starting this sort of effort.

Addresses Github issues:
    #57 
    #55 
    #54 
    #41 (partial)