### PR TITLE
Add Timestamp to the non-debug logger

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func initLogging(logName string) *os.File {
 
 func main() {
 	// initially log to console, we'll switch to a file once we know where to write it
-	log.SetFormatter(&log.TextFormatter{}) // default for logrus
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true}) // default for logrus
 	log.SetOutput(os.Stderr)
 	log.SetLevel(log.InfoLevel)
 


### PR DESCRIPTION
Logrus is cool, but the defaults are sort of annoying, things like no tty
having a different format, and Debug having Timestamps by default but higher
levels not.

This patch just adds Timestamp explicitly so it should be listed in every
message regardless of log level etc.  There's lots of room for improvement in
our logging but this is at least one samll step forward for reading gophers.

Partial BugFix for Issue: #61